### PR TITLE
Add public ecr repository for test

### DIFF
--- a/.github/workflows/gitaction.yml
+++ b/.github/workflows/gitaction.yml
@@ -14,7 +14,8 @@ env:
   # Organization Secrets
   AWS_ACCESS_KEY_ID: ${{ secrets.PERSONAL_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.PERSONAL_AWS_SECRET_ACCESS_KEY }}
-  ECR_REPOSITORY: 086230238707.dkr.ecr.ap-northeast-2.amazonaws.com
+  #ECR_REPOSITORY: 086230238707.dkr.ecr.ap-northeast-2.amazonaws.com
+  ECR_REPOSITORY: public.ecr.aws/x0e8v0p5/namejsjeongkr-sample
   AWS_REGION: ap-northeast-2 # AWS EKS & ECR이 위치한 AWS Region
   STAGE: demod_apnortheast2
   CLUSTER_NAME: demodapne2-abcd


### PR DESCRIPTION
- Push하는 ECR Repo를 Private에서 Public으로 변경 (교육 실습을 위해 교육생들이 Repo 내 이미지를 Pull 할 수 있도록 하기 위함)